### PR TITLE
Fix HICCS acronym

### DIFF
--- a/swesesci/publication.py
+++ b/swesesci/publication.py
@@ -60,7 +60,7 @@ class SSSPublication:
     emp_conf_list = ["ESEM", "EASE"]
     emp_journal_list = ["Empirical Software Engineering"]
     # 18 = Information Systems
-    is_conf_list = ["CaiSE", "ICEIS", "HICCS"]
+    is_conf_list = ["CaiSE", "ICEIS", "HICSS"]
     # 19 = Human Computer Interaction
     hci_conf_list = ["CHI", "INTERACT"]
     # 20 = High Assurance


### PR DESCRIPTION
## Summary
- fix a typo in conference name HICSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: sortedcontainers)*

------
https://chatgpt.com/codex/tasks/task_e_683fee3505c48327a2389b465786a7d8