### PR TITLE
Fix design vs construction journal mapping

### DIFF
--- a/swesesci/publication.py
+++ b/swesesci/publication.py
@@ -103,7 +103,7 @@ class SSSPublication:
         # 2 = Construction
         elif self.booktitle in self.constr_conf_list:
             self.knowl_area = 2
-        elif self.journal in self.design_journal_list:
+        elif self.journal in self.constr_journal_list:
             self.knowl_area = 2
         # 3 = Test
         elif self.booktitle in self.test_conf_list:


### PR DESCRIPTION
## Summary
- fix mapping of construction journals in assign_knowledge_areas

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sortedcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_683ff0018bec8327b62bacf72b8a13f3